### PR TITLE
feat: disable arm64 build

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -30,18 +30,18 @@ jobs:
             image_name_env: "DIFY_API_IMAGE_NAME"
             context: "api"
             platform: linux/amd64
-          - service_name: "build-api-arm64"
-            image_name_env: "DIFY_API_IMAGE_NAME"
-            context: "api"
-            platform: linux/arm64
+          # - service_name: "build-api-arm64"
+          #   image_name_env: "DIFY_API_IMAGE_NAME"
+          #   context: "api"
+          #   platform: linux/arm64
           - service_name: "build-web-amd64"
             image_name_env: "DIFY_WEB_IMAGE_NAME"
             context: "web"
             platform: linux/amd64
-          - service_name: "build-web-arm64"
-            image_name_env: "DIFY_WEB_IMAGE_NAME"
-            context: "web"
-            platform: linux/arm64
+          # - service_name: "build-web-arm64"
+          #   image_name_env: "DIFY_WEB_IMAGE_NAME"
+          #   context: "web"
+          #   platform: linux/arm64
 
     steps:
       - name: Prepare


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

## Summary by Sourcery

CI:
- Commented out ARM64 build configurations in the build-push.yml workflow, leaving only AMD64 platform builds active